### PR TITLE
Bitwise operators

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -27,7 +27,6 @@ module.exports = {
 		"lines-between-class-members": ["error", "always"],
 		"multiline-ternary": ["error", "never"],
 		"new-cap": "error",
-		"no-bitwise": "error",
 		"no-continue": "error",
 		"no-mixed-spaces-and-tabs": "error",
 		"no-multi-assign": "error",


### PR DESCRIPTION
# Bitwise operators
Bitwise operators are useful operators which can be used to perform tasks on bit patterns. These operators are useful, and in the scope of our projects, potentially necessary to be used (discord uses bitwise OR to work out permissions for a role). This PR is a proposition to not cause ES lint to error upon occurrence of a bitwise operator.